### PR TITLE
lazy load blink.cmp, luasnip, friendly-snippets, nvim-lspconfig

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -39,11 +39,15 @@
           version = pin.revision;
           optional = builtins.elem pname [
             "auto-save.nvim"
+            "blink.cmp"
             "bufferline.nvim"
             "catppuccin.nvim"
             "conform.nvim"
+            "friendly-snippets"
             "lualine.nvim"
+            "LuaSnip"
             "nvim-autopairs"
+            "nvim-lspconfig"
             "noice.nvim"
           ];
         }

--- a/nvim/lua/config/completion/init.lua
+++ b/nvim/lua/config/completion/init.lua
@@ -1,53 +1,78 @@
-require("luasnip").setup({})
-require("luasnip.loaders.from_vscode").lazy_load()
+local lzn = require("lz.n")
 
-require("blink.cmp").setup({
-  completion = {
-    list = {
-      selection = { auto_insert = false, preselect = false },
-    },
-    menu = {
-      draw = {
-        columns = {
-          { "label", "label_description", gap = 1 },
-          { "kind_icon", "kind", gap = 1 },
-          { "source_name" },
+lzn.load({
+  "LuaSnip",
+  lazy = true,
+  after = function()
+    require("luasnip").setup({})
+  end,
+})
+
+lzn.load({
+  "friendly-snippets",
+  lazy = true,
+  after = function()
+    require("luasnip.loaders.from_vscode").lazy_load()
+  end,
+})
+
+lzn.load({
+  "blink.cmp",
+  lazy = true,
+  before = function()
+    lzn.trigger_load("LuaSnip")
+    lzn.trigger_load("friendly-snippets")
+  end,
+  after = function()
+    require("blink.cmp").setup({
+      completion = {
+        list = {
+          selection = { auto_insert = false, preselect = false },
         },
-        components = {
-          kind_icon = {
-            text = function(ctx)
-              local icon = ctx.kind_icon
+        menu = {
+          draw = {
+            columns = {
+              { "label", "label_description", gap = 1 },
+              { "kind_icon", "kind", gap = 1 },
+              { "source_name" },
+            },
+            components = {
+              kind_icon = {
+                text = function(ctx)
+                  local icon = ctx.kind_icon
 
-              if vim.tbl_contains({ "Path" }, ctx.source_name) then
-                local dev_icon, _ = require("nvim-web-devicons").get_icon(ctx.label)
-                if dev_icon then
-                  icon = dev_icon
-                end
-              else
-                icon = require("lspkind").symbolic(ctx.kind, { mode = "symbol" })
-              end
+                  if vim.tbl_contains({ "Path" }, ctx.source_name) then
+                    local dev_icon, _ = require("nvim-web-devicons").get_icon(ctx.label)
+                    if dev_icon then
+                      icon = dev_icon
+                    end
+                  else
+                    icon = require("lspkind").symbolic(ctx.kind, { mode = "symbol" })
+                  end
 
-              return icon .. ctx.icon_gap
-            end,
-          },
-          source_name = {
-            text = function(ctx)
-              local source_to_text = {
-                Buffer = "[Buffer]",
-                LSP = "[LSP]",
-                Path = "[Path]",
-                Snippets = "[LuaSnip]",
-              }
+                  return icon .. ctx.icon_gap
+                end,
+              },
+              source_name = {
+                text = function(ctx)
+                  local source_to_text = {
+                    Buffer = "[Buffer]",
+                    LSP = "[LSP]",
+                    Path = "[Path]",
+                    Snippets = "[LuaSnip]",
+                  }
 
-              return source_to_text[ctx.source_name]
-            end,
+                  return source_to_text[ctx.source_name]
+                end,
+              },
+            },
           },
         },
+        documentation = { auto_show = true, auto_show_delay_ms = 500 },
       },
-    },
-    documentation = { auto_show = true, auto_show_delay_ms = 500 },
-  },
-  keymap = { preset = "enter" },
-  signature = { enabled = true },
-  snippets = { preset = "luasnip" },
+      keymap = { preset = "enter" },
+      signature = { enabled = true },
+      snippets = { preset = "luasnip" },
+    })
+  end,
 })

--- a/nvim/lua/config/lsp/init.lua
+++ b/nvim/lua/config/lsp/init.lua
@@ -1,161 +1,172 @@
-local lspconfig = require("lspconfig")
-local snacks = require("snacks")
-local wk = require("which-key")
+local lzn = require("lz.n")
 
-local virtual_lines_format = function(diagnostic)
-  return string.format("%s (%s)", diagnostic.message, diagnostic.source)
-end
+lzn.load({
+  "nvim-lspconfig",
+  event = { "BufReadPost", "BufWritePost", "BufNewFile" },
+  before = function()
+    lzn.trigger_load("blink.cmp")
+  end,
+  after = function()
+    local lspconfig = require("lspconfig")
+    local snacks = require("snacks")
+    local wk = require("which-key")
 
-vim.diagnostic.config({
-  virtual_lines = { format = virtual_lines_format },
-})
+    local virtual_lines_format = function(diagnostic)
+      return string.format("%s (%s)", diagnostic.message, diagnostic.source)
+    end
 
-require("lazydev").setup()
+    vim.diagnostic.config({
+      virtual_lines = { format = virtual_lines_format },
+    })
 
-local client_capabilities = require("blink.cmp").get_lsp_capabilities()
+    require("lazydev").setup()
 
-local goto_picker_opts = {
-  layout = { fullscreen = true },
-}
+    local client_capabilities = require("blink.cmp").get_lsp_capabilities()
 
-local jump_to_diagnostic = function(count)
-  if not vim.b.current_min_severity then
-    vim.b.current_min_severity = vim.diagnostic.severity.HINT
-  end
+    local goto_picker_opts = {
+      layout = { fullscreen = true },
+    }
 
-  vim.diagnostic.jump({
-    count = count,
-    float = false,
-    severity = { min = vim.b.current_min_severity },
-  })
-end
-
-local refresh_diagnostic_severity = function()
-  vim.diagnostic.config({
-    virtual_lines = {
-      format = virtual_lines_format,
-      severity = { min = vim.b.current_min_severity },
-    },
-    underline = {
-      severity = { min = vim.b.current_min_severity },
-    },
-  })
-end
-
-local on_attach = function(client, buffer)
-  wk.add({
-    {
-      "<leader>g",
-      buffer = buffer,
-      desc = "+[g]oto(lsp)",
-      icon = " ",
-    },
-    {
-      "<leader>gd",
-      buffer = buffer,
-      function()
-        snacks.picker.lsp_definitions(goto_picker_opts)
-      end,
-      desc = "[d]efinitions",
-    },
-    {
-      "<leader>gD",
-      buffer = buffer,
-      function()
-        snacks.picker.lsp_declarations(goto_picker_opts)
-      end,
-      desc = "[D]eclarations",
-    },
-    {
-      "<leader>gi",
-      buffer = buffer,
-      function()
-        snacks.picker.lsp_implementations(goto_picker_opts)
-      end,
-      desc = "[i]mplementations",
-    },
-    {
-      "<leader>gr",
-      buffer = buffer,
-      function()
-        snacks.picker.lsp_references(goto_picker_opts)
-      end,
-      desc = "[r]eferences",
-    },
-    {
-      "<leader>gt",
-      buffer = buffer,
-      function()
-        snacks.picker.lsp_type_definitions(goto_picker_opts)
-      end,
-      desc = "[t]ype definitions",
-    },
-    {
-      "<leader>l",
-      buffer = buffer,
-      desc = "+[l]sp",
-    },
-    {
-      "<leader>ld",
-      buffer = buffer,
-      desc = "+[d]iagnostics",
-    },
-    {
-      "<leader>lda",
-      buffer = buffer,
-      function()
+    local jump_to_diagnostic = function(count)
+      if not vim.b.current_min_severity then
         vim.b.current_min_severity = vim.diagnostic.severity.HINT
-        refresh_diagnostic_severity()
-      end,
-      desc = "[a]ll",
-    },
-    {
-      "<leader>lde",
-      buffer = buffer,
-      function()
-        vim.b.current_min_severity = vim.diagnostic.severity.ERROR
-        refresh_diagnostic_severity()
-      end,
-      desc = "[e]rror",
-    },
-    {
-      "<leader>ldn",
-      buffer = buffer,
-      function()
-        jump_to_diagnostic(1)
-      end,
-      desc = "[n]ext",
-    },
-    {
-      "<leader>ldp",
-      buffer = buffer,
-      function()
-        jump_to_diagnostic(-1)
-      end,
-      desc = "[p]rev",
-    },
-    {
-      "<leader>ldt",
-      buffer = buffer,
-      function()
-        vim.diagnostic.enable(not vim.diagnostic.is_enabled())
-      end,
-      desc = "[t]oggle",
-      icon = " ",
-    },
-  })
+      end
 
-  if client and client:supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
-    vim.lsp.inlay_hint.enable(true, { bufnr = buffer })
-  end
-end
+      vim.diagnostic.jump({
+        count = count,
+        float = false,
+        severity = { min = vim.b.current_min_severity },
+      })
+    end
 
-lspconfig.lua_ls.setup({
-  capabilities = client_capabilities,
-  on_attach = on_attach,
-})
+    local refresh_diagnostic_severity = function()
+      vim.diagnostic.config({
+        virtual_lines = {
+          format = virtual_lines_format,
+          severity = { min = vim.b.current_min_severity },
+        },
+        underline = {
+          severity = { min = vim.b.current_min_severity },
+        },
+      })
+    end
 
-lspconfig.nixd.setup({
-  capabilities = client_capabilities,
-  on_attach = on_attach,
+    local on_attach = function(client, buffer)
+      wk.add({
+        {
+          "<leader>g",
+          buffer = buffer,
+          desc = "+[g]oto(lsp)",
+          icon = " ",
+        },
+        {
+          "<leader>gd",
+          buffer = buffer,
+          function()
+            snacks.picker.lsp_definitions(goto_picker_opts)
+          end,
+          desc = "[d]efinitions",
+        },
+        {
+          "<leader>gD",
+          buffer = buffer,
+          function()
+            snacks.picker.lsp_declarations(goto_picker_opts)
+          end,
+          desc = "[D]eclarations",
+        },
+        {
+          "<leader>gi",
+          buffer = buffer,
+          function()
+            snacks.picker.lsp_implementations(goto_picker_opts)
+          end,
+          desc = "[i]mplementations",
+        },
+        {
+          "<leader>gr",
+          buffer = buffer,
+          function()
+            snacks.picker.lsp_references(goto_picker_opts)
+          end,
+          desc = "[r]eferences",
+        },
+        {
+          "<leader>gt",
+          buffer = buffer,
+          function()
+            snacks.picker.lsp_type_definitions(goto_picker_opts)
+          end,
+          desc = "[t]ype definitions",
+        },
+        {
+          "<leader>l",
+          buffer = buffer,
+          desc = "+[l]sp",
+        },
+        {
+          "<leader>ld",
+          buffer = buffer,
+          desc = "+[d]iagnostics",
+        },
+        {
+          "<leader>lda",
+          buffer = buffer,
+          function()
+            vim.b.current_min_severity = vim.diagnostic.severity.HINT
+            refresh_diagnostic_severity()
+          end,
+          desc = "[a]ll",
+        },
+        {
+          "<leader>lde",
+          buffer = buffer,
+          function()
+            vim.b.current_min_severity = vim.diagnostic.severity.ERROR
+            refresh_diagnostic_severity()
+          end,
+          desc = "[e]rror",
+        },
+        {
+          "<leader>ldn",
+          buffer = buffer,
+          function()
+            jump_to_diagnostic(1)
+          end,
+          desc = "[n]ext",
+        },
+        {
+          "<leader>ldp",
+          buffer = buffer,
+          function()
+            jump_to_diagnostic(-1)
+          end,
+          desc = "[p]rev",
+        },
+        {
+          "<leader>ldt",
+          buffer = buffer,
+          function()
+            vim.diagnostic.enable(not vim.diagnostic.is_enabled())
+          end,
+          desc = "[t]oggle",
+          icon = " ",
+        },
+      })
+
+      if client and client:supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
+        vim.lsp.inlay_hint.enable(true, { bufnr = buffer })
+      end
+    end
+
+    lspconfig.lua_ls.setup({
+      capabilities = client_capabilities,
+      on_attach = on_attach,
+    })
+
+    lspconfig.nixd.setup({
+      capabilities = client_capabilities,
+      on_attach = on_attach,
+    })
+  end,
 })


### PR DESCRIPTION
Fixes https://github.com/venkyr77/neovim-flake/issues/4

before `blink.cmp` and lazy-loading completion, lspconfig:

```
110.867  000.001: --- NVIM STARTED ---
```

after:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/49bcd101-b2ec-4bd0-b9c4-556aa83d3c00" />

```
082.904  000.001: --- NVIM STARTED ---
```

startup time boost from 110 ms to 82 ms :)

detailed startup log:

```
--- Startup times for process: Primary (or UI client) ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.002  000.002: --- NVIM STARTING ---
000.133  000.131: event init
000.228  000.095: early init
000.286  000.058: locale set
000.342  000.056: init first window
000.701  000.359: inits 1
000.707  000.006: window checked
000.710  000.002: parsing arguments
001.135  000.037  000.037: require('vim.shared')
001.209  000.029  000.029: require('vim.inspect')
001.261  000.044  000.044: require('vim._options')
001.263  000.125  000.052: require('vim._editor')
001.264  000.192  000.031: require('vim._init_packages')
001.272  000.370: init lua interpreter
003.298  002.026: nvim_ui_attach
003.498  000.200: nvim_set_client_info
003.500  000.002: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.002  000.002: --- NVIM STARTING ---
000.100  000.099: event init
000.169  000.069: early init
000.224  000.055: locale set
000.266  000.042: init first window
000.618  000.352: inits 1
000.630  000.012: window checked
000.632  000.002: parsing arguments
000.996  000.032  000.032: require('vim.shared')
001.069  000.030  000.030: require('vim.inspect')
001.105  000.027  000.027: require('vim._options')
001.107  000.109  000.051: require('vim._editor')
001.108  000.156  000.016: require('vim._init_packages')
001.112  000.323: init lua interpreter
001.158  000.046: expanding arguments
001.177  000.019: inits 2
001.394  000.217: init highlight
001.395  000.001: waiting for UI
001.494  000.099: done waiting for UI
001.497  000.003: clear screen
001.615  000.010  000.010: require('vim.keymap')
002.224  000.118  000.118: sourcing nvim_exec2()
003.025  000.726  000.726: require('vim.termcap')
003.061  000.023  000.023: require('vim.text')
003.132  001.633  000.756: require('vim._defaults')
003.134  000.004: init default mappings & autocommands
003.207  000.048  000.048: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/ftplugin.vim
003.252  000.017  000.017: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/indent.vim
011.126  000.138  000.138: require('config.options')
011.310  000.102  000.102: require('lz.n')
011.435  000.122  000.122: require('lz.n.spec')
011.751  000.105  000.105: require('lz.n.loader')
011.824  000.072  000.072: require('lz.n.handler.state')
011.827  000.273  000.096: require('lz.n.handler.cmd')
011.966  000.139  000.139: require('lz.n.handler.event')
012.023  000.055  000.055: require('lz.n.handler.ft')
012.143  000.120  000.120: require('lz.n.handler.keys')
012.210  000.064  000.064: require('lz.n.handler.colorscheme')
012.259  000.048  000.048: require('lz.n.handler.lazy')
012.262  000.814  000.115: require('lz.n.handler')
012.537  000.273  000.273: require('vim.iter')
020.064  006.848  006.848: require('catppuccin')
020.362  000.052  000.052: require('catppuccin.lib.hashing')
020.438  000.047  000.047: require('catppuccin.palettes')
020.471  000.030  000.030: require('catppuccin.palettes.mocha')
022.092  001.436  001.436: sourcing /nix/store/v1id6q0rf8q5q0z6wmxz6jbjcr5yb149-neovim-pack-dir/pack/mnw/opt/catppuccin.nvim/colors/catppuccin.vim
022.115  010.987  001.262: require('config.editor.colorscheme')
023.280  001.038  001.038: require('which-key')
023.523  000.238  000.238: require('which-key.config')
023.589  001.472  000.197: require('config.editor.which-key')
023.874  000.189  000.189: require('snacks')
023.938  000.348  000.159: require('config.editor.snacks')
024.122  000.183  000.183: require('config.editor.auto-save')
024.313  000.190  000.190: require('config.editor.bufferline')
024.703  000.004  000.004: require('vim.F')
024.711  000.183  000.179: require('gitsigns.async')
024.832  000.120  000.120: require('gitsigns.debug.log')
025.087  000.254  000.254: require('gitsigns.config')
025.090  000.672  000.115: require('gitsigns')
025.457  000.314  000.314: require('gitsigns.highlight')
025.790  000.070  000.070: require('gitsigns.debounce')
025.800  001.485  000.430: require('config.editor.gitsigns')
026.089  000.036  000.036: require('guess-indent.utils')
026.248  000.157  000.157: require('guess-indent.config')
026.250  000.380  000.186: require('guess-indent')
026.275  000.474  000.095: require('config.editor.guess-indent')
026.492  000.216  000.216: require('config.editor.lualine')
026.633  000.139  000.139: require('config.editor.noice')
026.799  000.165  000.165: require('config.editor.nvim-autopairs')
027.271  000.121  000.121: require('todo-comments.util')
027.279  000.312  000.192: require('todo-comments.config')
027.670  000.270  000.270: require('todo-comments.highlight')
027.672  000.392  000.122: require('todo-comments.jump')
027.673  000.807  000.102: require('todo-comments')
027.685  000.885  000.078: require('config.editor.todo-comments')
029.759  000.115  000.115: require('vim.treesitter.language')
029.797  000.035  000.035: require('vim.func')
029.903  000.099  000.099: require('vim.func._memoize')
029.963  000.885  000.635: require('vim.treesitter.query')
030.049  000.085  000.085: require('vim.treesitter._range')
030.059  001.452  000.482: require('vim.treesitter.languagetree')
030.063  001.633  000.181: require('vim.treesitter')
030.065  001.727  000.094: require('nvim-treesitter.compat')
031.383  000.966  000.966: require('nvim-treesitter.parsers')
031.531  000.145  000.145: require('nvim-treesitter.utils')
031.536  001.346  000.235: require('nvim-treesitter.ts_utils')
031.540  001.474  000.128: require('nvim-treesitter.tsrange')
031.620  000.079  000.079: require('nvim-treesitter.caching')
031.626  003.533  000.253: require('nvim-treesitter.query')
031.634  003.876  000.343: require('nvim-treesitter.configs')
031.686  004.000  000.124: require('config.editor.treesitter')
031.925  000.167  000.167: require('smartyank')
031.951  000.264  000.096: require('config.editor.smartyank')
032.153  000.201  000.201: require('config.completion')
032.297  000.143  000.143: require('config.format')
032.483  000.184  000.184: require('config.lsp')
032.793  000.221  000.221: require('lint')
032.802  000.318  000.097: require('config.lint')
032.803  029.188  007.398: require('config')
032.804  029.408  000.220: sourcing /nix/store/v1id6q0rf8q5q0z6wmxz6jbjcr5yb149-neovim-pack-dir/init.lua
032.808  000.202: sourcing vimrc file(s)
034.974  002.095  002.095: sourcing nvim_exec2() called at /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/filetype.lua:0
034.978  002.144  000.049: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/filetype.lua
037.724  000.056  000.056: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/syntax/synload.vim
037.795  000.169  000.113: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/syntax/syntax.vim
044.614  000.099  000.099: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/gzip.vim
045.189  000.108  000.108: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
045.278  000.643  000.535: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/matchit.vim
045.388  000.093  000.093: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/matchparen.vim
045.983  000.146  000.146: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/pack/dist/opt/netrw/plugin/netrwPlugin.vim
046.089  000.678  000.532: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/netrwPlugin.vim
046.255  000.144  000.144: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/rplugin.vim
046.313  000.036  000.036: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/shada.vim
046.359  000.013  000.013: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/spellfile.vim
046.434  000.052  000.052: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/tarPlugin.vim
046.471  000.012  000.012: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/tutor.vim
046.577  000.084  000.084: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/zipPlugin.vim
046.643  000.037  000.037: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/editorconfig.lua
046.740  000.045  000.045: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/man.lua
046.806  000.043  000.043: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/osc52.lua
046.850  000.023  000.023: sourcing /nix/store/la3xdxfnyg8pd0jxnvp5azlsgdbdbqa7-neovim-unwrapped-nightly/share/nvim/runtime/plugin/tohtml.lua
046.881  009.757: loading rtp plugins
062.894  000.036  000.036: require('vim.fs')
062.921  000.176  000.141: require('vim.lsp.log')
063.474  000.550  000.550: require('vim.lsp.protocol')
064.468  000.990  000.990: require('vim.lsp.util')
064.769  000.134  000.134: require('vim.lsp.sync')
064.773  000.302  000.169: require('vim.lsp._changetracking')
065.114  000.099  000.099: require('vim.lsp._transport')
065.185  000.004  000.004: require('string.buffer')
065.187  000.062  000.059: require('vim._stringbuffer')
065.190  000.415  000.253: require('vim.lsp.rpc')
065.261  013.847  011.413: require('vim.lsp')
065.539  000.276  000.276: require('blink.cmp')
066.041  000.237  000.237: require('blink.cmp.lib.async')
066.246  000.055  000.055: require('blink.cmp.config.utils')
066.310  000.062  000.062: require('blink.cmp.config.keymap')
066.388  000.030  000.030: require('blink.cmp.config.completion.keyword')
066.425  000.035  000.035: require('blink.cmp.config.completion.trigger')
066.461  000.035  000.035: require('blink.cmp.config.completion.list')
066.505  000.043  000.043: require('blink.cmp.config.completion.accept')
066.625  000.119  000.119: require('blink.cmp.config.completion.menu')
066.686  000.060  000.060: require('blink.cmp.config.completion.documentation')
066.718  000.031  000.031: require('blink.cmp.config.completion.ghost_text')
066.719  000.407  000.054: require('blink.cmp.config.completion')
066.774  000.054  000.054: require('blink.cmp.config.fuzzy')
066.848  000.074  000.074: require('blink.cmp.config.sources')
066.898  000.049  000.049: require('blink.cmp.config.signature')
066.964  000.065  000.065: require('blink.cmp.config.snippets')
067.003  000.037  000.037: require('blink.cmp.config.appearance')
067.039  000.035  000.035: require('blink.cmp.config.modes.cmdline')
067.068  000.028  000.028: require('blink.cmp.config.modes.term')
067.070  001.027  000.160: require('blink.cmp.config')
067.110  000.040  000.040: require('blink.cmp.lib.event_emitter')
067.114  001.574  000.271: require('blink.cmp.sources.lib')
067.179  015.788  000.092: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/blink-cmp/plugin/blink-cmp.lua
068.026  000.124  000.124: require('nvim-treesitter.info')
068.196  000.168  000.168: require('nvim-treesitter.shell_command_selectors')
068.211  000.666  000.374: require('nvim-treesitter.install')
068.291  000.079  000.079: require('nvim-treesitter.statusline')
068.429  000.136  000.136: require('nvim-treesitter.query_predicates')
068.434  000.979  000.097: require('nvim-treesitter')
068.824  001.398  000.419: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/nvim-treesitter/plugin/nvim-treesitter.lua
068.943  000.035  000.035: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/nvim-web-devicons/plugin/nvim-web-devicons.vim
069.095  000.062  000.062: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/rainbow-delimiters.nvim/plugin/rainbow-delimiters.lua
069.180  000.017  000.017: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/smartyank.nvim/plugin/smartyank.lua
069.251  000.008  000.008: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/snacks.nvim/plugin/snacks.lua
069.351  000.025  000.025: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/todo-comments.nvim/plugin/todo.vim
075.652  000.021  000.021: sourcing /nix/store/zlr7icq8jl50vpkg9k8cak91q0ddi28y-start-configdir/pack/mnw/start/which-key.nvim/plugin/which-key.lua
075.777  011.542: loading packages
075.788  000.011: loading after plugins
075.797  000.009: inits 3
077.113  001.315: reading ShaDa
077.473  000.360: opening buffers
077.642  000.158  000.158: require('snacks.explorer')
078.513  000.817  000.817: require('vim.diagnostic')
078.526  000.078: BufEnter autocommands
078.528  000.002: editing files in windows
078.545  000.017: VimEnter autocommands
079.137  000.320  000.320: require('snacks.util')
079.201  000.649  000.329: require('snacks.scroll')
079.419  000.199  000.199: require('snacks.animate')
079.629  000.138  000.138: require('snacks.picker')
079.882  000.250  000.250: require('snacks.picker.config')
080.130  000.246  000.246: require('snacks.picker.config.highlights')
080.387  000.255  000.255: require('snacks.picker.config.defaults')
080.773  000.384  000.384: require('snacks.picker.config.sources')
080.913  000.139  000.139: require('snacks.picker.config.layouts')
082.638  000.116  000.116: require('vim.ui')
082.683  001.762: UIEnter autocommands
082.685  000.002: before starting main loop
082.903  000.217: first screen update
082.904  000.001: --- NVIM STARTED ---
```